### PR TITLE
ADD ami build script, docker install script

### DIFF
--- a/aws/Packer/ami_create.json
+++ b/aws/Packer/ami_create.json
@@ -1,0 +1,49 @@
+{
+    "variables": {
+        "name": "ubuntu-docker-ce-base",
+        "aws-region": "ap-northeast-2",
+        "ami-name": "packer_ubuntu_18.04 {{timestamp}}",
+        "ec2-instance-type": "t2.micro",
+        "aws-ssh-username": "ubuntu"
+    },
+    "builders": [
+        {
+            "name": "ubuntu-docker-ce",
+            "type": "amazon-ebs",
+            "region": "{{user `aws-region`}}",
+            "instance_type": "{{user `ec2-instance-type`}}",
+            "source_ami": "ami-0ba5cd124d7a79612",
+            "ssh_username": "{{user `aws-ssh-username`}}",
+            "ssh_timeout": "60m",
+            "ami_name": "{{user `ami-name`}}"
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "shell",
+            "inline": [
+                "mkdir /home/$USER/.docker"
+            ]
+        },
+        {
+            "type": "file",
+            "source": "/root/.docker/config.json",
+            "destination": "/home/$USER/.docker/config.json"
+        },
+        {
+            "type": "file",
+            "source": "docker.sh",
+            "destination": "./docker.sh"
+        },
+
+        {
+            "type": "shell",
+            "inline": [
+                "chmod +x docker.sh",
+                "./docker.sh",
+                "sleep 5",
+                "rm docker.sh"
+            ]
+        }
+    ]
+}

--- a/aws/Packer/docker.sh
+++ b/aws/Packer/docker.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+sudo apt-get update -y
+sudo apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+echo \
+"deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+$(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update -y
+sudo apt-get install -y docker-ce=5:20.10.7~3-0~ubuntu-bionic docker-ce-cli=5:20.10.7~3-0~ubuntu-bionic containerd.io
+
+sudo usermod -aG docker $(whoami)
+sudo systemctl start docker
+sudo systemctl enable docker
+
+sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
ami_create.json 파일은 packer로 aws AMI 이미지를 빌드함.
내부에서 docker.sh 스크립트 파일을 실행하여 docker와 doc
ker-compose가 설치된 AMI 이미지가 만들어짐. 기존에 docke
r.sh 파일이 실행권한이 없다고 표시되어서 에러가 났었는데
, chmod +x docker.sh 명령어를 통해 에러를 해결.